### PR TITLE
LwException: Fix typehint error

### DIFF
--- a/LemonWay/Lib/LwException.php
+++ b/LemonWay/Lib/LwException.php
@@ -10,7 +10,7 @@ class LwException extends \Exception
     const NOT_FOUND = 404;
     const INTERNAL_ERROR = 500;
 
-    public function __construct($message, $code = 0, Exception $previous = null)
+    public function __construct($message, $code = 0, \Exception $previous = null)
     {
         parent::__construct($message, $code, $previous);
     }


### PR DESCRIPTION
It fix `PHP Fatal error:  Uncaught TypeError: Argument 3 passed to LemonWay\Lib\LwException::__construct() must be an instance of LemonWay\Lib\Exception`.

You can reproduce this with `new LemonWay\Lib\LwException('', 0, new \Exception());`
