### PR TITLE
Composer: use PSR4 autoload

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,6 @@
     "ext-openssl": "*"
   },
   "autoload": {
-    "psr-4": { "LemonWay\\": "" },
-    "files": ["LemonWay/Autoloader.php"]
+    "psr-4": { "LemonWay\\": "LemonWay/" }
   }
 }


### PR DESCRIPTION
Why use a custom autoloader while Composer can do the job ? ;)

All the examples stil use the "old" autoloader.
