### PR TITLE
Enable SSL check by default

### DIFF
--- a/LemonWay/LemonWayAPI.php
+++ b/LemonWay/LemonWayAPI.php
@@ -20,7 +20,7 @@ class LemonWayAPI
     /**
      * LemonWayKit constructor.
      */
-    public function __construct($directKitUrl = '', $webKitUrl = '',  $login = '', $password = '', $lang = 'fr', $debug = false, $sslVerification = false)
+    public function __construct($directKitUrl = '', $webKitUrl = '',  $login = '', $password = '', $lang = 'fr', $debug = false, $sslVerification = true)
     {
         $this->config = new Lib\Config();
         $this->config->dkUrl = $directKitUrl;


### PR DESCRIPTION
Last week we opened a pull request + a mail to the support (without answer!) for the SSL verification which was disabled.
https://github.com/lemonwaysas/php-client-directkit-xml/pull/14

You "fixed it", with a parameter, but, do you know that the default value is the wrong value for production?..
https://github.com/lemonwaysas/php-client-directkit-xml/commit/ed9831038999ea6f7cdc4c69e3005e0c0e18b0c0
This parameter is just a hack for you, Lemonway developers, why we MUST define it to true in production? You can define it to false if you want when you are testing, but it must be true by default!

This is the third time we open an issue about SSL!
Guys, you are maintaning a **PAYMENT SDK**!
I really hope this is the last time I have to report something like this.