### PR TITLE
Remove useless parameter

### DIFF
--- a/LemonWay/LemonWayAPI.php
+++ b/LemonWay/LemonWayAPI.php
@@ -12,12 +12,6 @@ class LemonWayAPI
     public $config;
 
     /**
-     * Used for Debug mode
-     * @var boolean
-     */
-    private $printInputAndOutputXml = false;
-
-    /**
      * LemonWayKit constructor.
      */
     public function __construct($directKitUrl = '', $webKitUrl = '',  $login = '', $password = '', $lang = 'fr', $debug = false, $sslVerification = true)


### PR DESCRIPTION
Private `$printInputAndOutputXml` is never used and this file is big enough.