### PR TITLE
Unused local variable, its value is overwritten immediately

### DIFF
--- a/LemonWay/LemonWayAPI.php
+++ b/LemonWay/LemonWayAPI.php
@@ -875,7 +875,6 @@ class LemonWayAPI
                     libxml_use_internal_errors(true);
                     $xml = new \SimpleXMLElement($response);
                     //Retrieve result
-                    $content = '';
                     switch($methodName){
                         case 'UnregisterSddMandate':
                             $content = $xml->{$methodName . 'Response'}->{'UnRegisterSddMandateResult'};


### PR DESCRIPTION
`switch` sets `$content` in each case and there is a `default` case. 