### PR TITLE
Replace .fr with .com in the support email address

### DIFF
--- a/LemonWay/LemonWayAPI.php
+++ b/LemonWay/LemonWayAPI.php
@@ -816,14 +816,14 @@ class LemonWayAPI
     private function sendRequest($methodName, $params, $version)
     {
         $xmlns = 'Service_mb_xml';
-        
+
         $ua = '';
         if(isset($_SERVER['HTTP_USER_AGENT'])) {
             $ua = $_SERVER['HTTP_USER_AGENT'];
         } elseif($this->config->user_agent) {
             $ua = $this->config->user_agent;
         }
-        
+
         $ip = '';
         if (!empty($_SERVER['HTTP_CLIENT_IP'])) {
             $ip = $_SERVER['HTTP_CLIENT_IP'];
@@ -898,7 +898,7 @@ class LemonWayAPI
                         case 'GetChargebacks':
                             $content = $xml->{$methodName.'Response'}->{'GetChargeBacksResult'};
                             break;
-                        
+
                         default:
                             $content = $xml->{$methodName . 'Response'}->{$methodName . 'Result'};
                             break;
@@ -910,13 +910,13 @@ class LemonWayAPI
                     throw new LwException("Bad Request : The server cannot or will not process the request due to something that is perceived to be a client error", LwException::BAD_REQUEST);
                     break;
                 case 403:
-                    throw new LwException("IP is not allowed to access Lemon Way's API, please contact support@lemonway.fr", LwException::BAD_IP);
+                    throw new LwException("IP is not allowed to access Lemon Way's API, please contact support@lemonway.com", LwException::BAD_IP);
                     break;
                 case 404:
-                    throw new LwException("Check that the access URLs are correct. If yes, please contact support@lemonway.fr", LwException::NOT_FOUND);
+                    throw new LwException("Check that the access URLs are correct. If yes, please contact support@lemonway.com", LwException::NOT_FOUND);
                     break;
                 case 500:
-                    throw new LwException("Lemon Way internal server error, please contact support@lemonway.fr", LwException::INTERNAL_ERROR);
+                    throw new LwException("Lemon Way internal server error, please contact support@lemonway.com", LwException::INTERNAL_ERROR);
                     break;
                 default:
                     break;
@@ -942,7 +942,7 @@ class LemonWayAPI
         curl_setopt($ch, CURLOPT_URL, $this->config->wkUrl . "?moneyintoken=" . $moneyInToken . '&p=' . urlencode($cssUrl) . '&lang=' . $language);
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
         curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, $this->config->sslVerification);
-        
+
         $server_output = curl_exec($ch);
         if (curl_errno($ch)) {
             error_log('curl_err : ' . curl_error($ch));


### PR DESCRIPTION
When sending an email to `support@lemonway.fr`, you receive this : 

```
Bonjour,

Nous vous informons que suite à l'uniformisation et linternationalisation de notre nom de domaine en .com, entamé il y a environ un an, ladresse email support@lemonway.fr  nest plus disponible.

Tout email envoyé à cette adresse ne sera pas traité.

Merci de bien vouloir nous renvoyer votre demande à support@lemonway.com.

Nous vous souhaitons une belle journée,
LEMON WAY

Hello,

We inform you, that following the standardization and internationalization of our domain name in .com, started à year ago, the email address support@lemonway.fr is no longer available.

Every request sent to this email will not be processed

Thank you to send us back your request to support@lemonway.com. 

Have a lovely day,
LEMON WAY
```

This PR just replaces the support email address with the recommended one.